### PR TITLE
Fix "latest" download

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,30 @@ You can use it to run your tests on Sauce Labs !
 
 ```
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        name: Action Test
-        steps:
-            # ...
-            - uses: saucelabs/saucectl-run-action@v1
-            # ...
+  test:
+    runs-on: ubuntu-latest
+    name: Action Test
+    steps:
+      # ...
+      - uses: saucelabs/saucectl-run-action@v1
+      # ...
 ```
 
 ### Advanced
 
 ```
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        name: Action Test
-        steps:
-        - uses: saucelabs/saucectl-run-action@v1
-            with:
-                sauce-username: ${{ secrets.SAUCE_USERNAME }}
-                sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-                saucectl-version: v0.25.1
-                working-directory: ./testrunner-toolkit/cypress/
-                testing-environment: sauce
-
+  test:
+    runs-on: ubuntu-latest
+    name: Action Test
+    steps:
+      - uses: saucelabs/saucectl-run-action@v1
+        with:
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
+          saucectl-version: v0.25.1
+          working-directory: ./testrunner-toolkit/cypress/
+          testing-environment: sauce
 ```
 
 ## Inputs

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -11587,7 +11587,7 @@ async function selectCompatibleVersion(versionSpec) {
     
     const versions = response.data;
     for (let i = 0; i < versions.length; i++) {
-        if (versionSpec === undefined
+        if (versionSpec === undefined || versionSpec === "latest"
             || semver.satisfies(versions[i].tag_name, versionSpec)) {
             return versions[i];
         }

--- a/src/install.js
+++ b/src/install.js
@@ -30,7 +30,7 @@ async function selectCompatibleVersion(versionSpec) {
     
     const versions = response.data;
     for (let i = 0; i < versions.length; i++) {
-        if (versionSpec === undefined
+        if (versionSpec === undefined || versionSpec === "latest"
             || semver.satisfies(versions[i].tag_name, versionSpec)) {
             return versions[i];
         }

--- a/tests/install.spec.js
+++ b/tests/install.spec.js
@@ -13,7 +13,7 @@ beforeAll(() => {
 it("Version matching", async () => {
     // rewire wrapping
     const selectCompatibleVersion = install.selectCompatibleVersion;
-    const testCases = [["0.25.1", "v0.25.1"], ["0.25.0", "v0.25.0"], ["^0.25.0", "v0.25.1"], [">=0.24.0", "v0.25.1"], ["0.24.x", "v0.24.1"]];
+    const testCases = [["latest", "v0.25.1"], ["0.25.1", "v0.25.1"], ["0.25.0", "v0.25.0"], ["^0.25.0", "v0.25.1"], [">=0.24.0", "v0.25.1"], ["0.24.x", "v0.24.1"]];
     for (let i = 0; i < testCases.length; i++) {
         const scope = nock('https://api.github.com')
             .get('/repos/saucelabs/saucectl/releases')


### PR DESCRIPTION
Currently "latest" version download is broken, raising `Error: No saucectl version compatible with latest`.
This PR fixes that.

It also updates the documentation that get a indentation issue.