### PR TITLE
Add new flags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,39 @@ Skip execution of saucectl (only install binary).
 Suite to run.
 
 > Similar to `--suite <suite>` parameter available in saucectl.
+
+## concurrency
+
+Concurency to use.
+
+> Similar to `--ccy <ccy>` parameter available in saucectl.
+
+## env
+
+Environement variables to add.
+
+> Similar to `-e` parameter available in saucectl.
+
+Due to github actions limitation, environement variables needs to be passed as a string. \
+Example:
+```
+      - uses: saucelabs/saucectl-run-action@v1
+        with:
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
+          env: |
+            MY_FIRST_VAR=VALUE
+            MY_SECOND_VAR=VALUE
+```
+
+## showConsoleLog
+
+Display console.log when tests succeed
+
+> Similar to `--show-console-log` parameter available in saucectl.
+
+## logDir
+
+Path where to store logs.
+
+> Similar to `--logDir <path>` parameter available in saucectl.

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,16 @@ inputs:
   suite:
     description: Suite to be tested
     required: false
+  env:
+    description: Environment variables to pass to saucectl
+    required: false
+  showConsoleLog:
+    description: Display console.log when tests succeed
+    required: false
+    default: false
+  logDir:
+    description: Path where to store logs
+    required: false
 runs:
   using: 'node12'
   main: 'dist/main/index.js'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -11721,8 +11721,13 @@ async function saucectlRun(opts) {
     const { workingDirectory } = opts;
 
     if (workingDirectory) {
-        const stats = await lstat(workingDirectory);
-        if (!stats.isDirectory()) {
+        let stats;
+        try {
+            stats = await lstat(workingDirectory);
+        } catch {
+            core.warning(`${workingDirectory} is unexistant`);
+        }
+        if (!stats || !stats.isDirectory()) {
             core.setFailed(`${workingDirectory} does not exists.`);
             return false;
         }

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -11433,13 +11433,24 @@ const defaultConfig = {
     suite: undefined,
     tunnelId: undefined,
     tunnelParent: undefined,
+    env: {},
 };
+
+const getSettingObject = function(keys, defaultValue) {
+    for (const key of keys) {
+        const value = core.getInput(key);
+        if (value) {
+            return value;
+        }
+    }
+    return defaultValue;
+}
 
 const getSettingString = function(keys, defaultValue) {
     for (const key of keys) {
         const value = core.getInput(key)
         if (value) {
-            return core.getInput(key);
+            return value;
         }
     }
     return defaultValue;
@@ -11465,18 +11476,19 @@ const get = function() {
         suite: getSettingString(['suite'], defaultConfig.suite),
         tunnelId: getSettingString(['tunnel-id'], defaultConfig.tunnelId),
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
+        env: getSettingObject(['env'], defaultConfig.env),
     };
 
     if (sauceConfig.saucectlVersion != "latest") {
         if (!semver.valid(sauceConfig.saucectlVersion)) {
-            core.setFailed(`saucectl-version: ${sauceConfig}: invalid version format`);
+            core.setFailed(`saucectl-version: ${sauceConfig.saucectlVersion}: invalid version format`);
             sauceConfig.saucectlVersion = undefined;
         }
     }
     return sauceConfig;
 }
 
-module.exports = { get, defaultConfig, getSettingBool, getSettingString };
+module.exports = { get, defaultConfig, getSettingBool, getSettingString, getSettingObject };
 
 /***/ }),
 
@@ -11685,6 +11697,9 @@ function buildSaucectlArgs(opts) {
     }
     if (opts.tunnelParent) {
         args.push('--tunnel-parent', opts.tunnelParent);
+    }
+    for (const key in opts.env) {
+        args.push('-e', key, opts.env[key]);
     }
     return args;
 }

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -11433,6 +11433,8 @@ const defaultConfig = {
     suite: undefined,
     tunnelId: undefined,
     tunnelParent: undefined,
+    showConsoleLog: false,
+    logDir: undefined,
     env: {},
 };
 
@@ -11477,6 +11479,8 @@ const get = function() {
         tunnelId: getSettingString(['tunnel-id'], defaultConfig.tunnelId),
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
         env: getSettingObject(['env'], defaultConfig.env),
+        showConsoleLog: getSettingBool(['show-console-log'], defaultConfig.showConsoleLog),
+        logDir: getSettingString(['logDir'], defaultConfig.logDir),
     };
 
     if (sauceConfig.saucectlVersion != "latest") {
@@ -11697,6 +11701,15 @@ function buildSaucectlArgs(opts) {
     }
     if (opts.tunnelParent) {
         args.push('--tunnel-parent', opts.tunnelParent);
+    }
+    if (opts.sauceignore) {
+        args.push('--sauceignore', opts.sauceignore);
+    }
+    if (opts.showConsoleLog) {
+        args.push('--show-console-log');
+    }
+    if (opts.logDir) {
+        args.push('--logDir', opts.logDir)
     }
     for (const key in opts.env) {
         args.push('-e', key, opts.env[key]);

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -11435,17 +11435,19 @@ const defaultConfig = {
     tunnelParent: undefined,
     showConsoleLog: false,
     logDir: undefined,
-    env: {},
+    env: [],
 };
 
-const getSettingObject = function(keys, defaultValue) {
-    for (const key of keys) {
-        const value = core.getInput(key);
-        if (value) {
-            return value;
+const getEnvVariables = function(keys) {
+    const str = getSettingString(keys, "");
+    const lines = str.split("\n");
+    const envVars = [];
+    for (const line of lines) {
+        if (line !== "") {
+            envVars.push(line);
         }
     }
-    return defaultValue;
+    return envVars;
 }
 
 const getSettingString = function(keys, defaultValue) {
@@ -11478,7 +11480,7 @@ const get = function() {
         suite: getSettingString(['suite'], defaultConfig.suite),
         tunnelId: getSettingString(['tunnel-id'], defaultConfig.tunnelId),
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
-        env: getSettingObject(['env'], defaultConfig.env),
+        env: getEnvVariables(['env']),
         showConsoleLog: getSettingBool(['show-console-log'], defaultConfig.showConsoleLog),
         logDir: getSettingString(['logDir'], defaultConfig.logDir),
     };
@@ -11492,7 +11494,7 @@ const get = function() {
     return sauceConfig;
 }
 
-module.exports = { get, defaultConfig, getSettingBool, getSettingString, getSettingObject };
+module.exports = { get, defaultConfig, getSettingBool, getSettingString, getEnvVariables };
 
 /***/ }),
 
@@ -11711,8 +11713,8 @@ function buildSaucectlArgs(opts) {
     if (opts.logDir) {
         args.push('--logDir', opts.logDir)
     }
-    for (const key in opts.env) {
-        args.push('-e', `${key}=${opts.env[key]}`);
+    for (const env of opts.env || []) {
+        args.push('-e', env);
     }
     return args;
 }

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -11712,7 +11712,7 @@ function buildSaucectlArgs(opts) {
         args.push('--logDir', opts.logDir)
     }
     for (const key in opts.env) {
-        args.push('-e', key, opts.env[key]);
+        args.push('-e', `${key}=${opts.env[key]}`);
     }
     return args;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,8 @@ const defaultConfig = {
     suite: undefined,
     tunnelId: undefined,
     tunnelParent: undefined,
+    showConsoleLog: false,
+    logDir: undefined,
     env: {},
 };
 
@@ -60,6 +62,8 @@ const get = function() {
         tunnelId: getSettingString(['tunnel-id'], defaultConfig.tunnelId),
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
         env: getSettingObject(['env'], defaultConfig.env),
+        showConsoleLog: getSettingBool(['show-console-log'], defaultConfig.showConsoleLog),
+        logDir: getSettingBool(['logDir'], defaultConfig.logDir),
     };
 
     if (sauceConfig.saucectlVersion != "latest") {

--- a/src/config.js
+++ b/src/config.js
@@ -18,17 +18,19 @@ const defaultConfig = {
     tunnelParent: undefined,
     showConsoleLog: false,
     logDir: undefined,
-    env: {},
+    env: [],
 };
 
-const getSettingObject = function(keys, defaultValue) {
-    for (const key of keys) {
-        const value = core.getInput(key);
-        if (value) {
-            return value;
+const getEnvVariables = function(keys) {
+    const str = getSettingString(keys, "");
+    const lines = str.split("\n");
+    const envVars = [];
+    for (const line of lines) {
+        if (line !== "") {
+            envVars.push(line);
         }
     }
-    return defaultValue;
+    return envVars;
 }
 
 const getSettingString = function(keys, defaultValue) {
@@ -61,7 +63,7 @@ const get = function() {
         suite: getSettingString(['suite'], defaultConfig.suite),
         tunnelId: getSettingString(['tunnel-id'], defaultConfig.tunnelId),
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
-        env: getSettingObject(['env'], defaultConfig.env),
+        env: getEnvVariables(['env']),
         showConsoleLog: getSettingBool(['show-console-log'], defaultConfig.showConsoleLog),
         logDir: getSettingString(['logDir'], defaultConfig.logDir),
     };
@@ -75,4 +77,4 @@ const get = function() {
     return sauceConfig;
 }
 
-module.exports = { get, defaultConfig, getSettingBool, getSettingString, getSettingObject };
+module.exports = { get, defaultConfig, getSettingBool, getSettingString, getEnvVariables };

--- a/src/config.js
+++ b/src/config.js
@@ -63,7 +63,7 @@ const get = function() {
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
         env: getSettingObject(['env'], defaultConfig.env),
         showConsoleLog: getSettingBool(['show-console-log'], defaultConfig.showConsoleLog),
-        logDir: getSettingBool(['logDir'], defaultConfig.logDir),
+        logDir: getSettingString(['logDir'], defaultConfig.logDir),
     };
 
     if (sauceConfig.saucectlVersion != "latest") {

--- a/src/config.js
+++ b/src/config.js
@@ -16,13 +16,24 @@ const defaultConfig = {
     suite: undefined,
     tunnelId: undefined,
     tunnelParent: undefined,
+    env: {},
 };
+
+const getSettingObject = function(keys, defaultValue) {
+    for (const key of keys) {
+        const value = core.getInput(key);
+        if (value) {
+            return value;
+        }
+    }
+    return defaultValue;
+}
 
 const getSettingString = function(keys, defaultValue) {
     for (const key of keys) {
         const value = core.getInput(key)
         if (value) {
-            return core.getInput(key);
+            return value;
         }
     }
     return defaultValue;
@@ -48,15 +59,16 @@ const get = function() {
         suite: getSettingString(['suite'], defaultConfig.suite),
         tunnelId: getSettingString(['tunnel-id'], defaultConfig.tunnelId),
         tunnelParent: getSettingString(['tunnel-parent'],  defaultConfig.tunnelParent),
+        env: getSettingObject(['env'], defaultConfig.env),
     };
 
     if (sauceConfig.saucectlVersion != "latest") {
         if (!semver.valid(sauceConfig.saucectlVersion)) {
-            core.setFailed(`saucectl-version: ${sauceConfig}: invalid version format`);
+            core.setFailed(`saucectl-version: ${sauceConfig.saucectlVersion}: invalid version format`);
             sauceConfig.saucectlVersion = undefined;
         }
     }
     return sauceConfig;
 }
 
-module.exports = { get, defaultConfig, getSettingBool, getSettingString };
+module.exports = { get, defaultConfig, getSettingBool, getSettingString, getSettingObject };

--- a/src/run.js
+++ b/src/run.js
@@ -41,8 +41,8 @@ function buildSaucectlArgs(opts) {
     if (opts.logDir) {
         args.push('--logDir', opts.logDir)
     }
-    for (const key in opts.env) {
-        args.push('-e', `${key}=${opts.env[key]}`);
+    for (const env of opts.env || []) {
+        args.push('-e', env);
     }
     return args;
 }

--- a/src/run.js
+++ b/src/run.js
@@ -32,6 +32,15 @@ function buildSaucectlArgs(opts) {
     if (opts.tunnelParent) {
         args.push('--tunnel-parent', opts.tunnelParent);
     }
+    if (opts.sauceignore) {
+        args.push('--sauceignore', opts.sauceignore);
+    }
+    if (opts.showConsoleLog) {
+        args.push('--show-console-log');
+    }
+    if (opts.logDir) {
+        args.push('--logDir', opts.logDir)
+    }
     for (const key in opts.env) {
         args.push('-e', key, opts.env[key]);
     }

--- a/src/run.js
+++ b/src/run.js
@@ -51,8 +51,13 @@ async function saucectlRun(opts) {
     const { workingDirectory } = opts;
 
     if (workingDirectory) {
-        const stats = await lstat(workingDirectory);
-        if (!stats.isDirectory()) {
+        let stats;
+        try {
+            stats = await lstat(workingDirectory);
+        } catch {
+            core.warning(`${workingDirectory} is unexistant`);
+        }
+        if (!stats || !stats.isDirectory()) {
             core.setFailed(`${workingDirectory} does not exists.`);
             return false;
         }

--- a/src/run.js
+++ b/src/run.js
@@ -32,6 +32,9 @@ function buildSaucectlArgs(opts) {
     if (opts.tunnelParent) {
         args.push('--tunnel-parent', opts.tunnelParent);
     }
+    for (const key in opts.env) {
+        args.push('-e', key, opts.env[key]);
+    }
     return args;
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -42,7 +42,7 @@ function buildSaucectlArgs(opts) {
         args.push('--logDir', opts.logDir)
     }
     for (const key in opts.env) {
-        args.push('-e', key, opts.env[key]);
+        args.push('-e', `${key}=${opts.env[key]}`);
     }
     return args;
 }

--- a/tests/config.spec.js
+++ b/tests/config.spec.js
@@ -3,7 +3,7 @@ jest.mock("@actions/core");
 const core = require("@actions/core");
 const { expect } = require("@jest/globals");
 
-const { get, defaultConfig, getSettingBool, getSettingString } = require("../src/config");
+const { get, defaultConfig, getSettingBool, getSettingObject, getSettingString } = require("../src/config");
 
 let failed;
 
@@ -50,35 +50,82 @@ it("Config value accessor", async () => {
     }
 });
 
-it("Config default values", async () => {
+
+it("Config object values", async () => {
     testCases = [{
-        params: {},
-        expected: {
-            failed: false,
-            config: defaultConfig,
-        },
-    }, {
-        params: { 'saucectl-version': 'v3.zx-'},
+        params: { 'env': {'key1': 'val1', 'key2': 'val2'}},
+        requested: ['env'],
+        defaultValue: {},
         expected: {
             failed: true,
-            config: {...defaultConfig, saucectlVersion: undefined },
+            config: {...defaultConfig, env: { key1: 'val1', key2: 'val2'}},
         },
     }];
 
     delete process.env.SAUCE_USERNAME;
     delete process.env.SAUCE_ACCESS_KEY;
-    for (let i = 0; i < testCases.length; i++) {
+    for (const testCase of testCases) {
         failed = false;
 
-        const {params, expected} = testCases[i];
-        core.getInput.mockImplementation((key) => params[key]);
-        const failedFn = core.setFailed.mockImplementation(() => {});
+        const {params, requested, defaultValue, expected} = testCase;
+        const getCalls = core.getInput.mockImplementation((key) => params[key]);
 
-        const getResult = get()
+        const getResult = getSettingObject(requested, defaultValue);
+
+        expect(getResult).toEqual(expected.config.env);
+        getCalls.mockRestore();
+    }
+});
+
+
+it("Get global config", async () => {
+    testCases = [{
+        params: {},
+        expected: {
+            failed: false,
+            errMsg: undefined,
+            config: {...defaultConfig },
+        },
+    }, {
+        params: {
+            'saucectl-version': 'vX.Y-',
+        },
+        expected: {
+            failed: true,
+            errMsg: "saucectl-version: vX.Y-: invalid version format",
+            config: {...defaultConfig, saucectlVersion: undefined },
+        },
+    }, {
+        params: {
+            'saucectl-version': 'v0.1.2',
+        },
+        expected: {
+            failed: false,
+            errMsg: undefined,
+            config: {...defaultConfig, saucectlVersion: 'v0.1.2' },
+        },
+    }];
+
+    delete process.env.SAUCE_USERNAME;
+    delete process.env.SAUCE_ACCESS_KEY;
+    for (const testCase of testCases) {
+        let failed = false;
+        let error = undefined;
+
+        const {params, expected} = testCase;
+        const getCalls = core.getInput.mockImplementation((key) => params[key]);
+        const failedCalls = core.setFailed.mockImplementation((errMsg) => {
+            error = errMsg;
+            failed = true;
+        });
+
+        const getResult = get();
 
         expect(getResult).toEqual(expected.config);
-        if (expected.failed) {
-            expect(failedFn).toHaveBeenCalled();
-        }
+        expect(failed).toBe(expected.failed);
+        expect(error).toBe(expected.errMsg);
+
+        getCalls.mockRestore();
+        failedCalls.mockRestore();
     }
 });

--- a/tests/run.spec.js
+++ b/tests/run.spec.js
@@ -42,7 +42,7 @@ it("Argument builds", async () => {
         input: { ...config.defaultConfig, logDir: 'path/to/logs' },
         expected: ['run', '--logDir', 'path/to/logs']
     }, {
-        input: { ...config.defaultConfig, env: { key1: 'val1', key2: 'val2'}},
+        input: { ...config.defaultConfig, env: ['key1=val1', 'key2=val2']},
         expected: ['run', '-e', 'key1=val1', '-e', 'key2=val2']
     }];
 

--- a/tests/run.spec.js
+++ b/tests/run.spec.js
@@ -56,16 +56,30 @@ it("Argument builds", async () => {
 it('Start saucectl', async () => {
     childProcess.spawn.mockReturnValue({});
     const tests = [{
+        params: {},
         returnValue: 0,
         expectedValue: true
     }, {
+        params: {},
+        returnValue: 1,
+        expectedValue: false
+    }, {
+        params: {
+            workingDirectory: '.',
+        },
+        returnValue: 0,
+        expectedValue: true
+    }, {
+        params: {
+            workingDirectory: '/non-existent',
+        },
         returnValue: 1,
         expectedValue: false
     }];
     for (let i = 0; i < tests.length; i++) {
         const testCase = tests[i];
         helpers.awaitExecution.mockReturnValue(testCase.returnValue);
-        const status = await run.saucectlRun({});
+        const status = await run.saucectlRun(testCase.params);
         expect(status).toBe(testCase.expectedValue);
     }
 });

--- a/tests/run.spec.js
+++ b/tests/run.spec.js
@@ -11,22 +11,39 @@ it("Argument builds", async () => {
     const testCases = [{
         input: { ...config.defaultConfig },
         expected: ['run']
-    },
-    {
+    }, {
         input: { ...config.defaultConfig, configurationFile: '.sauce/custom-name.yml' },
         expected: ['run', '-c', '.sauce/custom-name.yml']
-    },
-    {
+    }, {
         input: { ...config.defaultConfig, runRegion: 'eu-central-1' },
         expected: ['run', '--region', 'eu-central-1']
-    },
-    {
+    }, {
         input: { ...config.defaultConfig, runEnvironment: 'sauce' },
         expected: ['run', '--test-env', 'sauce']
-    },
-    {
+    }, {
         input: { ...config.defaultConfig, suite: 'mySuiteName' },
         expected: ['run', '--suite', 'mySuiteName']
+    }, {
+        input: { ...config.defaultConfig, tunnelId: 'my-tunnel-id', tunnelParent: 'my-tunnel-parent' },
+        expected: ['run', '--tunnel-id', 'my-tunnel-id', '--tunnel-parent', 'my-tunnel-parent']
+    }, {
+        input: { ...config.defaultConfig, concurrency: 3 },
+        expected: ['run', '--ccy', 3]
+    }, {
+        input: { ...config.defaultConfig, timeout: 15 },
+        expected: ['run', '--timeout', 15]
+    }, {
+        input: { ...config.defaultConfig, sauceignore: 'my/.sauceignore' },
+        expected: ['run', '--sauceignore', 'my/.sauceignore']
+    }, {
+        input: { ...config.defaultConfig, showConsoleLog: true },
+        expected: ['run', '--show-console-log']
+    }, {
+        input: { ...config.defaultConfig, logDir: 'path/to/logs' },
+        expected: ['run', '--logDir', 'path/to/logs']
+    }, {
+        input: { ...config.defaultConfig, env: { key1: 'val1', key2: 'val2'}},
+        expected: ['run', '-e', 'key1=val1', '-e', 'key2=val2']
     }];
 
     for (let i = 0; i < testCases.length; i++) {


### PR DESCRIPTION
- Add support for `saucectl` supported flags:
  - `env`
  - `concurrency`
  - `showConsoleLog`
  - `logDir`

- Fix an issue when working-directory does not exists
- Pass `sauceignore` param when specified
- Enhance test coverage