### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Example:
             MY_SECOND_VAR=VALUE
 ```
 
-## showConsoleLog
+## show-console-log
 
-Display console.log when tests succeed
+Display console.log when tests succeed. Set to `true` to enable.
 
 > Similar to `--show-console-log` parameter available in saucectl.
 

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   skip-run:
     description: Skip execution of saucectl (only install binary)
-    default: false
+    default: "false"
     required: false
   suite:
     description: "[deprecated] Suite to be tested"
@@ -60,7 +60,7 @@ inputs:
   showConsoleLog:
     description: Display console.log when tests succeed
     required: false
-    default: false
+    default: "false"
   logDir:
     description: Path where to store logs
     required: false


### PR DESCRIPTION
README describes a `showConsoleLog` option, but the code expects `show-console-log`. Update README for consistency.