### PR TITLE
Add support for GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ jobs:
     steps:
       # ...
       - uses: saucelabs/saucectl-run-action@v2
+        env:
+          GITHUB_TOKEN: $${{ github.token }}
       # ...
 ```
+
+:warning: To avoid reaching `API rate limit exceeded` due to unauthenticated requests, be sure to provide `GITHUB_TOKEN` through `env` field.
 
 ### Advanced
 
@@ -27,6 +31,8 @@ jobs:
     name: Action Test
     steps:
       - uses: saucelabs/saucectl-run-action@v2
+        env:
+          GITHUB_TOKEN: $${{ github.token }}
         with:
           sauce-username: ${{ secrets.SAUCE_USERNAME }}
           sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -16364,7 +16364,17 @@ function getPlatform() {
 }
 
 async function selectCompatibleVersion(versionSpec) {
-    const octokit = new Octokit();
+    // NOTE: authStrategy is set conditionnaly. Docs specifies that GITHUB_TOKEN needs to be set explicitely.
+    //       To avoid breaking every pipeline that has no GITHUB_TOKEN set, this strategy is not passed until
+    //       a token is available.
+    //
+    // References:
+    //   - https://github.com/octokit/auth-action.js#createactionauth
+    //   - https://github.com/octokit/auth-action.js/blob/main/src/index.ts#L16-L20
+    //   - https://github.com/octokit/core.js/blob/main/src/index.ts#L121-L124
+    const octokit = new Octokit({
+        authStrategy: process.env.GITHUB_TOKEN ? createActionAuth : undefined,
+    });
     const response = await octokit.request("GET /repos/:org/:repo/releases", {
         org: "saucelabs",
         repo: "saucectl",

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5536,6 +5536,37 @@ module.exports = v4;
 
 /***/ }),
 
+/***/ 20:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+var authToken = __nccwpck_require__(334);
+
+const createActionAuth = function createActionAuth() {
+  if (!process.env.GITHUB_ACTION) {
+    throw new Error("[@octokit/auth-action] `GITHUB_ACTION` environment variable is not set. @octokit/auth-action is meant to be used in GitHub Actions only.");
+  }
+  const definitions = [process.env.GITHUB_TOKEN, process.env.INPUT_GITHUB_TOKEN, process.env.INPUT_TOKEN].filter(Boolean);
+  if (definitions.length === 0) {
+    throw new Error("[@octokit/auth-action] `GITHUB_TOKEN` variable is not set. It must be set on either `env:` or `with:`. See https://github.com/octokit/auth-action.js#createactionauth");
+  }
+  if (definitions.length > 1) {
+    throw new Error("[@octokit/auth-action] The token variable is specified more than once. Use either `with.token`, `with.GITHUB_TOKEN`, or `env.GITHUB_TOKEN`. See https://github.com/octokit/auth-action.js#createactionauth");
+  }
+  const token = definitions.pop();
+  return authToken.createTokenAuth(token);
+};
+
+exports.createActionAuth = createActionAuth;
+//# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
 /***/ 334:
 /***/ ((__unused_webpack_module, exports) => {
 
@@ -16309,6 +16340,7 @@ module.exports = { awaitExecution };
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { Octokit } = __nccwpck_require__(5375);
+const { createActionAuth } = __nccwpck_require__(20);
 const semver = __nccwpck_require__(1383);
 const os = __nccwpck_require__(2037);
 const tc = __nccwpck_require__(7784);
@@ -16670,6 +16702,12 @@ async function run() {
     if (!cfg) {
         core.setFailed("Invalid configuration.");
         return;
+    }
+
+    if (!process.env.GITHUB_TOKEN) {
+        core.warning('No GITHUB_TOKEN detected.')
+        core.warning('Be sure to explicitly set GITHUB_TOKEN in saucectl-run-action step of your workflow.');
+        core.warning('Unauthenticated usage may result in "API rate limit exceeded" error.');
     }
 
     // Install saucectl

--- a/dist/main/licenses.txt
+++ b/dist/main/licenses.txt
@@ -62,6 +62,31 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+@octokit/auth-action
+MIT
+The MIT License
+
+Copyright (c) 2019 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 @octokit/auth-token
 MIT
 The MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@actions/github": "^5.1.1",
         "@actions/tool-cache": "^2.0.1",
         "@octokit/action": "^4.0.8",
+        "@octokit/auth-action": "^2.0.3",
         "@octokit/rest": "^19.0.4",
         "semver": "^7.3.8"
       },
@@ -1160,15 +1161,28 @@
       }
     },
     "node_modules/@octokit/auth-action": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.0.1.tgz",
-      "integrity": "sha512-nh5UTN22jK7ll2BR+zS7yZXB6u9q2lsI+teOhdC/JCfws8guKjH3NynV0ipwERnwP11/GiHJ48Ji+HC5+R92ag==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.0.3.tgz",
+      "integrity": "sha512-GtUtNR7AmDV8bjNtt+EuqwE2Ipeq0aR10zPInp/B6msgoXL7UPqj2bI+8M/A/y7abGJ3U4h85wXoqZSralnDxw==",
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
-        "@octokit/types": "^7.0.0"
+        "@octokit/types": "^9.0.0"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/openapi-types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^16.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -3346,9 +3360,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -3394,9 +3408,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.set": {
@@ -5258,12 +5272,27 @@
       }
     },
     "@octokit/auth-action": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.0.1.tgz",
-      "integrity": "sha512-nh5UTN22jK7ll2BR+zS7yZXB6u9q2lsI+teOhdC/JCfws8guKjH3NynV0ipwERnwP11/GiHJ48Ji+HC5+R92ag==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-2.0.3.tgz",
+      "integrity": "sha512-GtUtNR7AmDV8bjNtt+EuqwE2Ipeq0aR10zPInp/B6msgoXL7UPqj2bI+8M/A/y7abGJ3U4h85wXoqZSralnDxw==",
       "requires": {
         "@octokit/auth-token": "^3.0.0",
-        "@octokit/types": "^7.0.0"
+        "@octokit/types": "^9.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+        },
+        "@octokit/types": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+          "requires": {
+            "@octokit/openapi-types": "^16.0.0"
+          }
+        }
       }
     },
     "@octokit/auth-token": {
@@ -7004,9 +7033,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "kleur": {
@@ -7037,9 +7066,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.set": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@actions/github": "^5.1.1",
     "@actions/tool-cache": "^2.0.1",
     "@octokit/action": "^4.0.8",
+    "@octokit/auth-action": "^2.0.3",
     "@octokit/rest": "^19.0.4",
     "semver": "^7.3.8"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,12 @@ async function run() {
         return;
     }
 
+    if (!process.env.GITHUB_TOKEN) {
+        core.warning('No GITHUB_TOKEN detected.')
+        core.warning('Be sure to explicitly set GITHUB_TOKEN in saucectl-run-action step of your workflow.');
+        core.warning('Unauthenticated usage may result in "API rate limit exceeded" error.');
+    }
+
     // Install saucectl
     if (!await saucectlInstall({ versionSpec: cfg.saucectlVersion })) {
         return;

--- a/src/install.js
+++ b/src/install.js
@@ -1,4 +1,5 @@
 const { Octokit } = require("@octokit/rest");
+const { createActionAuth } = require("@octokit/auth-action");
 const semver = require("semver");
 const os = require('os');
 const tc = require('@actions/tool-cache');

--- a/src/install.js
+++ b/src/install.js
@@ -23,7 +23,17 @@ function getPlatform() {
 }
 
 async function selectCompatibleVersion(versionSpec) {
-    const octokit = new Octokit();
+    // NOTE: authStrategy is set conditionnaly. Docs specifies that GITHUB_TOKEN needs to be set explicitely.
+    //       To avoid breaking every pipeline that has no GITHUB_TOKEN set, this strategy is not passed until
+    //       a token is available.
+    //
+    // References:
+    //   - https://github.com/octokit/auth-action.js#createactionauth
+    //   - https://github.com/octokit/auth-action.js/blob/main/src/index.ts#L16-L20
+    //   - https://github.com/octokit/core.js/blob/main/src/index.ts#L121-L124
+    const octokit = new Octokit({
+        authStrategy: process.env.GITHUB_TOKEN ? createActionAuth : undefined,
+    });
     const response = await octokit.request("GET /repos/:org/:repo/releases", {
         org: "saucelabs",
         repo: "saucectl",


### PR DESCRIPTION
This PR adds supports for `GITHUB_TOKEN`.

README.md updated to warn for the risk of reach API Rate limit.

- If provided to the step: relies on this to authenticate to github.
- If not provided, displays a warning message:
<img width="1130" alt="Screenshot 2023-01-25 at 10 50 10" src="https://user-images.githubusercontent.com/11074879/214532500-7718d9de-1775-4762-b7bf-3b9c119ae497.png">

[Example Pipeline](https://github.com/FriggaHel/saucectl-cypress-example/actions/runs/4004677651/jobs/6874107405#step:3:13)

