### PR TITLE
fix: Revert node version in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,5 +63,5 @@ inputs:
     required: false
     default: "false"
 runs:
-  using: 'node22'
+  using: 'node20'
   main: 'dist/main/index.js'


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Parameter ''using: node22' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead.'