### PR TITLE
Add spacing between the logo and the title in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
   </a>
 </p>
 
+<br>
+
 # Saucectl Run Action from Sauce Labs
 
 This action installs [saucectl](https://github.com/saucelabs/saucectl/) and launches tests. \


### PR DESCRIPTION
GitHub's markdown sanitizer strips style attributes, so a margin on the logo paragraph has no effect. A <br> surrounded by blank lines is the reliable equivalent; the blank lines matter, since without them the following heading is absorbed into the HTML block and renders as literal text instead of an <h1>.

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
